### PR TITLE
Add Cursor agent skills from other mab-go repos

### DIFF
--- a/.cursor/skills/ask-questions/SKILL.md
+++ b/.cursor/skills/ask-questions/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: ask-questions
+description: Forces the agent to use the AskQuestion tool to gather structured multiple-choice input from the user. Use when invoked via /ask-questions, or when the user says phrases like "ask me questions", "clarify first", "gather requirements", "make sure you have context", or "what do you need to know".
+---
+
+# Ask Questions
+
+When this skill is triggered, you MUST use the `AskQuestion` tool to gather structured input. Do not ask questions conversationally - always invoke the tool.
+
+## Workflow
+
+1. **Identify the topic**: From the slash command argument (e.g. `/ask-questions about the deployment strategy`) or surrounding context.
+2. **Draft questions**: Identify the unknowns that would most change your approach; focus on high-signal decisions.
+3. **Invoke AskQuestion**: Ask all questions in a single call unless a later question depends on the answer to an earlier one.
+4. **Proceed contextually**: After receiving answers, take the most appropriate next action (implement, plan, summarize, etc.); only pause to ask permission if you have no basis to determine what to do next.
+
+## Question design
+
+- Prefer 3–5 options per question; cover the realistic space without being exhaustive. Never make up options just to reach the 3-5 guidance, however.
+- Include an "Agent decides" or "Other" escape hatch only when the option space is genuinely open-ended.
+- Set `allow_multiple` to `true` for questions where several answers can co-exist (e.g. "Which concerns apply?", "Which features do you want?").
+- Keep question text concise; one sentence per prompt.

--- a/.cursor/skills/make-todos/SKILL.md
+++ b/.cursor/skills/make-todos/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: make-todos
+description: Creates a structured TodoWrite task list for the current work. Use when the user invokes /make-todos, or when the task involves multiple steps where later steps depend on earlier ones completing first.
+---
+
+# Make Todos
+
+Invoke the `TodoWrite` tool immediately. Do not describe what you are about to do; just call the tool.
+
+## When to apply
+
+- User explicitly invokes `/make-todos`
+- The work has 3+ steps where later steps depend on earlier ones completing first
+
+Do **not** create todos for single-step tasks, trivial changes, or purely conversational requests.
+
+## Task decomposition guidelines
+
+- Each todo should represent one focused, completable unit of work; not a whole feature, not a single line change.
+- Order todos so earlier ones unblock later ones.
+- Name todos as actions: "Add X", "Update Y", "Fix Z" - not nouns like "Error handling".
+- If the full scope is unclear, create todos for what is known and add more as the work unfolds.
+
+## Behavior after creating todos
+
+1. Mark the first todo `in_progress`.
+2. Start working on it in the same response - do not pause to announce the plan.
+3. Mark each todo `completed` immediately when done, then mark the next todo `in_progress`.
+4. Only one todo should be `in_progress` at a time.

--- a/.cursor/skills/review-plan-todos/SKILL.md
+++ b/.cursor/skills/review-plan-todos/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: review-plan-todos
+description: Review To-Do items in a plan file's YAML frontmatter for completeness and clarity. Use after producing or updating a plan in Cursor Plan mode.
+---
+
+# To-Do Review
+
+After producing or updating a plan in Cursor Plan mode, critically review each To-Do item in the plan file's YAML frontmatter.
+
+## What to check
+
+- **Incomplete**: The item lacks enough detail to implement unambiguously. A capable agent should not need to make assumptions to carry it out.
+- **Composite**: The item covers multiple distinct changes that could succeed or fail independently. Split these into separate items.
+- **Ambiguous**: The item has no clear completion criterion. You cannot tell, just by reading it, when it is done.
+- **Trivial**: The item tracks nothing meaningful on its own - it will be completed automatically as a side-effect of another item, or is so self-evident it adds no value to the list.
+- **Misordered**: Items are sequenced in a way that would cause a blocker (e.g., a step depends on a later step).
+
+## Output
+
+- List each problematic item, identify which category applies, and state the specific issue.
+- Suggest a concrete fix (reword, split, reorder, or remove).
+- If the list is already solid, say so briefly.
+- **Do not edit the plan yet.** Present findings and offer to apply the changes.
+
+## Applying changes (only after user approval)
+
+Edit the YAML frontmatter in-place once the user approves.

--- a/.cursor/skills/review-plan/SKILL.md
+++ b/.cursor/skills/review-plan/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: review-plan
+description: Review plans from Cursor Plan mode for accuracy, correctness, and clarity. Use when reviewing a plan before implementation or when the user asks for plan review.
+---
+
+# Plan Review
+
+When reviewing a plan (e.g. from Cursor's Plan mode), apply the following review.
+
+## Review directive
+
+Take another look at the plan. Double-check it for accuracy and correctness. Are there any areas where you're being vague or ambiguous? Are there places where you're saying something outright incorrect?
+
+It's important that you be sure, because the agent implementing this plan may not be you: it may be an agent with a lower skill level than your own, so you must make sure the plan is rock-solid. Don't spell things out like you're addressing an unintelligent coding agent, though.
+
+Strike a balance between completeness/correctness and being overly prescriptive or verbose.
+
+## What to check
+
+- **Accuracy**: Facts, file paths, API names, and technical claims are correct.
+- **Correctness**: Steps are logically sound and will achieve the stated goal; no contradictions or impossible sequences.
+- **Clarity**: No vague or ambiguous wording; a different agent could follow the plan without guessing.
+- **Actionability**: Each step is concrete enough to implement; "consider X" is only used where real alternatives exist.
+- **Unknowns/Assumptions**: Identify missing context that prevents a confident review and flag assumptions that need confirmation.
+- **Brevity**: No unnecessary detail or condescending over-explanation; assume a capable implementer.
+
+## Output
+
+- Summarize what you verified and any issues found.
+- If you find errors, vagueness, or ambiguity, state them clearly and suggest concrete fixes. **Do not edit the plan yet.** Present findings to the user and offer to apply the changes.
+- If required context is missing, ask targeted clarifying question(s) before proposing final fixes so recommendations are grounded.
+- If the plan is solid, say so briefly; no need to repeat the plan.
+
+## Applying changes (only after user approval)
+
+- Prefer **editing the plan document in-place**. If a substantial portion of the plan would change (e.g. \>40%), you may create a new document instead of updating in place.
+- Proceed with updates only after the user explicitly approves.


### PR DESCRIPTION
Bring in the shared SKILL.md set used across mab-go Go projects so this repo gets the same ask-questions, make-todos, and plan-review workflows in Cursor.