### PR TITLE
Add GitHub Actions CI and Codecov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go build ./...
+      - run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+      - uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: coverage.out
+          fail_ci_if_error: true
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.3
+
+  cyclomatic-complexity:
+    name: cyclomatic-complexity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Generate gocyclo report (non-blocking)
+        run: make setup && ( make cyclo 2>&1 | tee cyclo.txt; exit 0 )
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cyclomatic-complexity
+          path: cyclo.txt

--- a/README.md
+++ b/README.md
@@ -5,11 +5,20 @@ A programming toolkit for interacting with NMEA data. Written in Go (golang).
 
 Requires **Go 1.26** or newer.
 
-[![codecov](https://codecov.io/gh/mab-go/nmea/branch/master/graph/badge.svg)](https://codecov.io/gh/mab-go/nmea)
+[![codecov](https://codecov.io/gh/mab-go/nmea/branch/main/graph/badge.svg)](https://codecov.io/gh/mab-go/nmea)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mab-go/nmea)](https://goreportcard.com/report/github.com/mab-go/nmea)
 [![Go Reference](https://pkg.go.dev/badge/github.com/mab-go/nmea.svg)](https://pkg.go.dev/github.com/mab-go/nmea)
 
 ## Development
+
+### Codecov
+
+CI uploads coverage from GitHub Actions using [`codecov/codecov-action@v5`](https://github.com/codecov/codecov-action) with **OIDC** (`use_oidc: true`), so no upload token is required in the workflow once Codecov trusts GitHub for this repository.
+
+1. Install the [Codecov GitHub app](https://github.com/apps/codecov) for **`mab-go`** and grant access to **`nmea`** (maintainers: also confirm the repo is enabled on [codecov.io](https://codecov.io) and the default branch is **`main`**).
+2. If uploads fail or your Codecov setup requires a repository token, add a **`CODECOV_TOKEN`** repository secret and follow the action README to pass `token: ${{ secrets.CODECOV_TOKEN }}` (and drop OIDC if you switch to token-based upload).
+
+Coverage status checks are **informational** (see [`codecov.yml`](codecov.yml)); a failed upload step still fails CI.
 
 ### Running Tests
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Run build, race tests with coverage, golangci-lint, and a non-blocking gocyclo report (artifact) on push and pull_request. Upload coverage.out to Codecov via OIDC; keep project and patch status informational so coverage does not fail the merge gate.

Document Codecov setup in the README and point the badge at main.

Closes #4