### PR TITLE
Set Codecov default branch to main

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  branch: main
+
 coverage:
   status:
     project:


### PR DESCRIPTION
Codecov was treating `master` as the default branch. Adding the `codecov.branch` setting to `codecov.yml` tells Codecov to use `main` as the default for coverage comparisons and the badge.