### PR TITLE
Migrate enum generation to dmarkham/enumer v1.6.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ OPEN ?= $(shell command -v xdg-open 2>/dev/null || echo "open")
 
 .PHONY: help \
         setup \
+        generate \
         test test\:cover \
         lint lint\:fix fmt vet cyclo \
         mod\:tidy mod\:verify \
@@ -108,6 +109,13 @@ vet: ## Run go vet
 cyclo: ## Run gocyclo; run 'make setup' first
 	@test -x $(GOCYCLO) || (echo "Run 'make setup' to install gocyclo" && exit 1)
 	$(GOCYCLO) -over 10 .
+
+#------------------------------------------------------------------------------
+# Generate
+#------------------------------------------------------------------------------
+
+generate: ## Run go generate ./...
+	go generate ./...
 
 #------------------------------------------------------------------------------
 # Module

--- a/sentence/gpgga/enum.go
+++ b/sentence/gpgga/enum.go
@@ -56,4 +56,4 @@ const (
 	SimulationFixQuality // 8
 )
 
-//go:generate enumer -type=NorthSouth,EastWest,FixQuality -text -linecomment -transform=first-upper -output=enum_gen.go
+//go:generate go run github.com/dmarkham/enumer@v1.6.3 -type=NorthSouth,EastWest,FixQuality -text -linecomment -transform=first-upper -output=enum_gen.go

--- a/sentence/gpgga/enum_gen.go
+++ b/sentence/gpgga/enum_gen.go
@@ -56,7 +56,7 @@ func NorthSouthString(s string) (NorthSouth, error) {
 	return 0, fmt.Errorf("%s does not belong to NorthSouth values", s)
 }
 
-// NorthSouthValuDataStatus,Modees returns all values of the enum
+// NorthSouthValues returns all values of the enum
 func NorthSouthValues() []NorthSouth {
 	return _NorthSouthValues
 }

--- a/sentence/gpgll/enum.go
+++ b/sentence/gpgll/enum.go
@@ -57,4 +57,4 @@ const (
 	InvalidMode // N
 )
 
-//go:generate enumer -type=NorthSouth,EastWest,DataStatus,Mode -text -linecomment -transform=first-upper -output=enum_gen.go
+//go:generate go run github.com/dmarkham/enumer@v1.6.3 -type=NorthSouth,EastWest,DataStatus,Mode -text -linecomment -transform=first-upper -output=enum_gen.go


### PR DESCRIPTION
The original `enumer` tool (alvaroloes/enumer) is abandoned. This commit switches the two //go:generate directives to the maintained fork (dmarkham/enumer), using `go run module@version` so no pre-installed binary is required.

Changes:
- Update `//go:generate` in `sentence/gpgga/enum.go` and `sentence/gpgll/enum.go` to invoke `go run github.com/dmarkham/enumer@v1.6.3`
- Regenerate `sentence/gpgga/enum_gen.go`; fixes a garbled comment in the old output (`NorthSouthValuDataStatus,Modees` -> `NorthSouthValues`)
- Add `generate` target to `Makefile` (`go generate ./...`) and register it in `.PHONY`