### PR TITLE
Add NMEATime type and replace float32 fix-time fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ NMEA 0183 sentence:
 
 - **`VerifyChecksum`** — validates the `*XX` checksum on a raw sentence string
 - **`SegmentParser`** — splits a sentence into typed fields (`AsFloat64`,
-  `AsInt16`, `AsString`, and more)
+  `AsInt16`, `AsString`, `AsNMEATime`, and more)
+- **`NMEATime`** — UTC fix time as hour/minute/second/millisecond (no float
+  precision loss)
 
 ---
 

--- a/sentence/gpgga/gpgga.go
+++ b/sentence/gpgga/gpgga.go
@@ -8,10 +8,10 @@ import (
 
 // GPGGA represents an NMEA sentence of type "GPGGA".
 type GPGGA struct {
-	// FixTime is the time at which the GPS fix was acquired. The format is (h)hmmss.sss. For
-	// example, the value 174831.864 represents the time 17:48:31.864. It is element [1] of a
-	// GPGGA sentence.
-	FixTime float32
+	// FixTime is the time at which the GPS fix was acquired (typically UTC). It is element [1] of
+	// a GPGGA sentence. An empty time field yields a zero [sentence.NMEATime] without error. Wire
+	// format and validation: see [sentence.NMEATime].
+	FixTime sentence.NMEATime
 
 	// Latitude is the "latitude" component of a GPS fix. The format is (d)ddmm.mmmm. For example,
 	// the value 4807.038 represents a latitude value of 48° 7.038'. It is element [2] of a GPGGA
@@ -94,7 +94,7 @@ func Parse(s string) (*GPGGA, error) {
 
 	_ = segments.RequireString(0, "GPGGA") // Verify sentence type
 	gpgga := &GPGGA{
-		FixTime:        segments.AsFloat32(1),
+		FixTime:        segments.AsNMEATime(1),
 		Latitude:       segments.AsFloat64(2),
 		NorthSouth:     segments.AsNorthSouth(3),
 		Longitude:      segments.AsFloat64(4),

--- a/sentence/gpgga/gpgga_test.go
+++ b/sentence/gpgga/gpgga_test.go
@@ -3,6 +3,8 @@ package gpgga
 import (
 	"fmt"
 	"testing"
+
+	"github.com/mab-go/nmea/sentence"
 )
 
 type testVec struct {
@@ -15,7 +17,7 @@ var goodTestData = map[string]testVec{
 	"NMEA Generator [1/1]": {
 		input: "$GPGGA,174800.864,4002.741,N,07618.550,W,1,12,1.0,0.0,M,0.0,M,,*70",
 		expected: GPGGA{
-			FixTime:        174800.864,
+			FixTime:        sentence.NMEATime{Hour: 17, Minute: 48, Second: 0, Millisecond: 864},
 			Latitude:       4002.741,
 			NorthSouth:     North,
 			Longitude:      7618.55,
@@ -32,7 +34,7 @@ var goodTestData = map[string]testVec{
 	"Garmin G12 (v 4.57)": {
 		input: "$GPGGA,183730,3907.356,N,12102.482,W,1,05,1.6,646.4,M,-24.1,M,300,123*76",
 		expected: GPGGA{
-			FixTime:        183730.0,
+			FixTime:        sentence.NMEATime{Hour: 18, Minute: 37, Second: 30, Millisecond: 0},
 			Latitude:       3907.356,
 			NorthSouth:     North,
 			Longitude:      12102.482,
@@ -51,7 +53,7 @@ var goodTestData = map[string]testVec{
 	"Garmin eTrex Summit": {
 		input: "$GPGGA,002454,3553.5295,N,13938.6570,E,1,05,2.2,18.3,M,39.0,M,,*7F",
 		expected: GPGGA{
-			FixTime:        2454.0,
+			FixTime:        sentence.NMEATime{Hour: 0, Minute: 24, Second: 54, Millisecond: 0},
 			Latitude:       3553.5295,
 			NorthSouth:     North,
 			Longitude:      13938.657,
@@ -74,7 +76,7 @@ var badTestData = map[string]testVec{
 	},
 	"Bad FixTime": {
 		input:  "$GPGGA,bad_FixTime,4002.741,N,07618.550,W,1,12,1.0,0.0,M,0.0,M,,*34",
-		errMsg: "sentence segment [1] must be parsable as a float32 but was \"bad_FixTime\"",
+		errMsg: "sentence segment [1] must be parsable as an NMEATime but was \"bad_FixTime\"",
 	},
 	"Bad Latitude": {
 		input:  "$GPGGA,174800.864,bad_Latitude,N,07618.550,W,1,12,1.0,0.0,M,0.0,M,,*62",
@@ -150,7 +152,7 @@ func TestParse_goodData(t *testing.T) {
 		t.Run(title, func(t *testing.T) {
 			actual, err := Parse(vec.input)
 			if err != nil {
-				t.Fatalf("error creating GPGLL from NMEA input \"%v\": %v", title, err)
+				t.Fatalf("error creating GPGGA from NMEA input \"%v\": %v", title, err)
 			}
 
 			expected := vec.expected
@@ -215,11 +217,11 @@ func TestGPGGA_GetSentenceType(t *testing.T) {
 }
 
 func ExampleParse() {
-	sentence := "$GPGGA,023042,3907.3837,N,12102.4684,W,1,04,2.3,507.3,M,-24.1,M,,*75"
-	gpgga, err := Parse(sentence)
+	s := "$GPGGA,023042,3907.3837,N,12102.4684,W,1,04,2.3,507.3,M,-24.1,M,,*75"
+	gpgga, err := Parse(s)
 	_ = err
 
 	fmt.Printf("%+v", gpgga)
 	// Output:
-	// &{FixTime:23042 Latitude:3907.3837 NorthSouth:N Longitude:12102.4684 EastWest:W FixQuality:1 SatCount:4 HDOP:2.3 Altitude:507.3 AltitudeUOM:M GeoidHeight:-24.1 GeoidHeightUOM:M DGPSUpdateAge:0 DGPSStationID:0}
+	// &{FixTime:023042.000 Latitude:3907.3837 NorthSouth:N Longitude:12102.4684 EastWest:W FixQuality:1 SatCount:4 HDOP:2.3 Altitude:507.3 AltitudeUOM:M GeoidHeight:-24.1 GeoidHeightUOM:M DGPSUpdateAge:0 DGPSStationID:0}
 }

--- a/sentence/gpgll/gpgll.go
+++ b/sentence/gpgll/gpgll.go
@@ -27,10 +27,10 @@ type GPGLL struct {
 	// a GPGLL input.
 	EastWest EastWest
 
-	// FixTime is the time at which the GPS fix was acquired. The format is (h)hmmss.sss. For
-	// example, the value 174831.864 represents the time 17:48:31.864. It is element [5] of a
-	// GPGLL input.
-	FixTime float32
+	// FixTime is the time at which the GPS fix was acquired (typically UTC). It is element [5] of
+	// a GPGLL input. An empty time field yields a zero [sentence.NMEATime] without error. Wire
+	// format and validation: see [sentence.NMEATime].
+	FixTime sentence.NMEATime
 
 	// DataStatus represents the status of the GPS fix. It can be either "A" (valid) or "V"
 	// (invalid). It is element [6] of a GPGLL input.
@@ -64,7 +64,7 @@ func Parse(s string) (*GPGLL, error) {
 		NorthSouth: segments.AsNorthSouth(2),
 		Longitude:  segments.AsFloat64(3),
 		EastWest:   segments.AsEastWest(4),
-		FixTime:    segments.AsFloat32(5),
+		FixTime:    segments.AsNMEATime(5),
 		DataStatus: segments.AsDataStatus(6),
 		Mode:       segments.AsMode(7),
 	}

--- a/sentence/gpgll/gpgll_test.go
+++ b/sentence/gpgll/gpgll_test.go
@@ -3,6 +3,8 @@ package gpgll
 import (
 	"fmt"
 	"testing"
+
+	"github.com/mab-go/nmea/sentence"
 )
 
 type testVec struct {
@@ -19,7 +21,7 @@ var goodTestData = map[string]testVec{
 			NorthSouth: South,
 			Longitude:  11551.681852,
 			EastWest:   East,
-			FixTime:    215052.603,
+			FixTime:    sentence.NMEATime{Hour: 21, Minute: 50, Second: 52, Millisecond: 603},
 			DataStatus: ValidDataStatus,
 			Mode:       DifferentialMode,
 		},
@@ -31,7 +33,7 @@ var goodTestData = map[string]testVec{
 			NorthSouth: South,
 			Longitude:  11551.681852,
 			EastWest:   East,
-			FixTime:    215102.604,
+			FixTime:    sentence.NMEATime{Hour: 21, Minute: 51, Second: 2, Millisecond: 604},
 			DataStatus: ValidDataStatus,
 			Mode:       EstimatedMode,
 		},
@@ -43,7 +45,7 @@ var goodTestData = map[string]testVec{
 			NorthSouth: North,
 			Longitude:  12212.446039,
 			EastWest:   West,
-			FixTime:    214827.478,
+			FixTime:    sentence.NMEATime{Hour: 21, Minute: 48, Second: 27, Millisecond: 478},
 			DataStatus: ValidDataStatus,
 			Mode:       ManualInputMode,
 		},
@@ -55,7 +57,7 @@ var goodTestData = map[string]testVec{
 			NorthSouth: North,
 			Longitude:  12212.446039,
 			EastWest:   West,
-			FixTime:    214916.479,
+			FixTime:    sentence.NMEATime{Hour: 21, Minute: 49, Second: 16, Millisecond: 479},
 			DataStatus: ValidDataStatus,
 			Mode:       AutonomousMode,
 		},
@@ -68,7 +70,7 @@ var goodTestData = map[string]testVec{
 			NorthSouth: North,
 			Longitude:  12158.3416,
 			EastWest:   West,
-			FixTime:    161229.487,
+			FixTime:    sentence.NMEATime{Hour: 16, Minute: 12, Second: 29, Millisecond: 487},
 			DataStatus: ValidDataStatus,
 			Mode:       AutonomousMode,
 		},
@@ -98,7 +100,7 @@ var badTestData = map[string]testVec{
 	},
 	"Bad FixTime": {
 		input:  "$GPGLL,3723.2475,N,12158.3416,W,bad_FixTime,A,A*01",
-		errMsg: "sentence segment [5] must be parsable as a float32 but was \"bad_FixTime\"",
+		errMsg: "sentence segment [5] must be parsable as an NMEATime but was \"bad_FixTime\"",
 	},
 	"Bad DataStatus": {
 		input:  "$GPGLL,3723.2475,N,12158.3416,W,161229.487,bad_DataStatus,A*3C",
@@ -138,13 +140,13 @@ func TestParse_goodData(t *testing.T) {
 }
 
 func TestParse_invalidChecksum(t *testing.T) {
-	gpgga, err := Parse("$GPGLL,3723.2475,N,12158.3416,W,161229.487,A,A*FE")
+	gpgll, err := Parse("$GPGLL,3723.2475,N,12158.3416,W,161229.487,A,A*FE")
 	if err == nil {
 		t.Error("checksum verification passed (but should not have)")
 	}
 
-	if gpgga != nil {
-		t.Errorf("Parse result was incorrect, got: %v, want: %v", gpgga, nil)
+	if gpgll != nil {
+		t.Errorf("Parse result was incorrect, got: %v, want: %v", gpgll, nil)
 	}
 
 	expected := "calculated checksum value \"41\" does not match sentence-specified value of \"FE\""
@@ -156,13 +158,13 @@ func TestParse_invalidChecksum(t *testing.T) {
 func TestParse_badSegments(t *testing.T) {
 	for title, vec := range badTestData {
 		t.Run(title, func(t *testing.T) {
-			gpgga, err := Parse(vec.input)
+			gpgll, err := Parse(vec.input)
 			if err == nil {
 				t.Fatalf("parsing succeeded (but should not have) for test sentence %q", title)
 			}
 
-			if gpgga != nil {
-				t.Fatalf("result should have been <nil> but was %v for test sentence %q", gpgga, title)
+			if gpgll != nil {
+				t.Fatalf("result should have been <nil> but was %v for test sentence %q", gpgll, title)
 			}
 
 			if err.Error() != vec.errMsg {
@@ -180,11 +182,11 @@ func TestGPGLL_GetSentenceType(t *testing.T) {
 }
 
 func ExampleParse() {
-	sentence := "$GPGLL,3723.2475,N,12158.3416,W,161229.487,A,A*41"
-	gpgll, err := Parse(sentence)
+	s := "$GPGLL,3723.2475,N,12158.3416,W,161229.487,A,A*41"
+	gpgll, err := Parse(s)
 	_ = err
 
 	fmt.Printf("%+v", gpgll)
 	// Output:
-	// &{Latitude:3723.2475 NorthSouth:N Longitude:12158.3416 EastWest:W FixTime:161229.48 DataStatus:A Mode:A}
+	// &{Latitude:3723.2475 NorthSouth:N Longitude:12158.3416 EastWest:W FixTime:161229.487 DataStatus:A Mode:A}
 }

--- a/sentence/nmeatime.go
+++ b/sentence/nmeatime.go
@@ -1,0 +1,139 @@
+package sentence
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// NMEATime represents the time of fix as reported in an NMEA sentence (typically UTC for GPS).
+// The raw wire format is (h)hmmss.sss; this type unpacks that into discrete fields with no
+// floating-point precision loss. Parsing rules match [SegmentParser.AsNMEATime].
+//
+// Second = 60 is accepted only for UTC 23:59 (a leap second) and round-trips through String().
+type NMEATime struct {
+	Hour        int
+	Minute      int
+	Second      int
+	Millisecond int
+}
+
+// String returns the canonical wire encoding of t: two digits each for hour, minute, and second,
+// a period, and exactly three fractional digits (e.g. "174800.864"). Inputs that omit the
+// fractional part parse as millisecond zero; String always emits ".sss", so serialization
+// normalizes that case to ".000".
+//
+// The 10-character shape (before any wider hour field) applies to values produced by successful
+// parsing via [SegmentParser.AsNMEATime]; manually populated structs are not re-validated here.
+func (t NMEATime) String() string {
+	return fmt.Sprintf("%02d%02d%02d.%03d", t.Hour, t.Minute, t.Second, t.Millisecond)
+}
+
+// parseNMEATime parses a raw NMEA time segment string (format: (h)hmmss[.s[s[s]]]) into an
+// NMEATime without any floating-point conversion. The integer part must be 4–6 digits. If more
+// than three fractional digits are present, the remainder is truncated (not rounded).
+func parseNMEATime(s string) (NMEATime, error) {
+	parts := strings.Split(s, ".")
+	if len(parts) > 2 {
+		return NMEATime{}, fmt.Errorf("too many decimal points")
+	}
+
+	hour, minute, second, err := parseNMEATimeIntPart(parts[0])
+	if err != nil {
+		return NMEATime{}, err
+	}
+
+	ms, err := parseNMEATimeFracPart(parts)
+	if err != nil {
+		return NMEATime{}, err
+	}
+
+	if err := validateNMEATimeFields(hour, minute, second, ms); err != nil {
+		return NMEATime{}, err
+	}
+
+	return NMEATime{Hour: hour, Minute: minute, Second: second, Millisecond: ms}, nil
+}
+
+// parseNMEATimeIntPart extracts hour, minute, and second from the integer portion of an NMEA time
+// string (format: (h)hmmss — exactly 4, 5, or 6 ASCII digits).
+func parseNMEATimeIntPart(intPart string) (hour, minute, second int, err error) {
+	if len(intPart) < 4 || len(intPart) > 6 {
+		return 0, 0, 0, fmt.Errorf("integer part must be 4 to 6 digits")
+	}
+
+	secondStr := intPart[len(intPart)-2:]
+	minuteStr := intPart[len(intPart)-4 : len(intPart)-2]
+	hourStr := intPart[:len(intPart)-4]
+	if hourStr == "" {
+		hourStr = "0"
+	}
+
+	hour, err = strconv.Atoi(hourStr)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid hour")
+	}
+
+	minute, err = strconv.Atoi(minuteStr)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid minute")
+	}
+
+	second, err = strconv.Atoi(secondStr)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid second")
+	}
+
+	return hour, minute, second, nil
+}
+
+// parseNMEATimeFracPart extracts milliseconds from the split parts of an NMEA time string. If no
+// fractional part is present (len(parts) == 1), it returns 0. If the fractional run is longer than
+// three digits, only the first three are used; the rest are ignored.
+func parseNMEATimeFracPart(parts []string) (int, error) {
+	if len(parts) < 2 {
+		return 0, nil
+	}
+
+	fracStr := parts[1]
+	for len(fracStr) < 3 {
+		fracStr += "0"
+	}
+
+	ms, err := strconv.Atoi(fracStr[:3])
+	if err != nil {
+		return 0, fmt.Errorf("invalid fractional seconds")
+	}
+
+	return ms, nil
+}
+
+// validateNMEATimeFields checks that each field is within its valid NMEA range. Second may be 60
+// only for UTC 23:59 (leap second).
+func validateNMEATimeFields(hour, minute, second, ms int) error {
+	if hour < 0 || hour > 23 {
+		return fmt.Errorf("hour %d out of range [0, 23]", hour)
+	}
+	if minute < 0 || minute > 59 {
+		return fmt.Errorf("minute %d out of range [0, 59]", minute)
+	}
+	if err := validateNMEATimeSecond(hour, minute, second); err != nil {
+		return err
+	}
+	if ms < 0 || ms > 999 {
+		return fmt.Errorf("millisecond %d out of range [0, 999]", ms)
+	}
+
+	return nil
+}
+
+func validateNMEATimeSecond(hour, minute, second int) error {
+	if second < 0 || second > 60 {
+		return fmt.Errorf("second %d out of range [0, 60]", second)
+	}
+	if second == 60 && (hour != 23 || minute != 59) {
+		return fmt.Errorf("second 60 is only valid at UTC 23:59 (leap second)")
+	}
+
+	return nil
+}

--- a/sentence/nmeatime_test.go
+++ b/sentence/nmeatime_test.go
@@ -1,0 +1,243 @@
+package sentence
+
+import (
+	"errors"
+	"testing"
+)
+
+type nmeatimeVec struct {
+	input    string
+	expected NMEATime
+	canon    string // expected String() output
+}
+
+var validNMEATimeInputs = []nmeatimeVec{
+	{
+		input:    "174800.864",
+		expected: NMEATime{Hour: 17, Minute: 48, Second: 0, Millisecond: 864},
+		canon:    "174800.864",
+	},
+	{
+		input:    "161229.487",
+		expected: NMEATime{Hour: 16, Minute: 12, Second: 29, Millisecond: 487},
+		canon:    "161229.487",
+	},
+	{
+		input:    "215052.603",
+		expected: NMEATime{Hour: 21, Minute: 50, Second: 52, Millisecond: 603},
+		canon:    "215052.603",
+	},
+	{
+		input:    "000000.000",
+		expected: NMEATime{Hour: 0, Minute: 0, Second: 0, Millisecond: 0},
+		canon:    "000000.000",
+	},
+	{
+		input:    "002454",
+		expected: NMEATime{Hour: 0, Minute: 24, Second: 54, Millisecond: 0},
+		canon:    "002454.000",
+	},
+	{
+		input:    "2454",
+		expected: NMEATime{Hour: 0, Minute: 24, Second: 54, Millisecond: 0},
+		canon:    "002454.000",
+	},
+	{
+		input:    "183730",
+		expected: NMEATime{Hour: 18, Minute: 37, Second: 30, Millisecond: 0},
+		canon:    "183730.000",
+	},
+	{
+		input:    "30000.5",
+		expected: NMEATime{Hour: 3, Minute: 0, Second: 0, Millisecond: 500},
+		canon:    "030000.500",
+	},
+	{
+		input:    "30000.05",
+		expected: NMEATime{Hour: 3, Minute: 0, Second: 0, Millisecond: 50},
+		canon:    "030000.050",
+	},
+	{
+		input:    "235960.000",
+		expected: NMEATime{Hour: 23, Minute: 59, Second: 60, Millisecond: 0},
+		canon:    "235960.000",
+	},
+	{
+		input:    "235959.000",
+		expected: NMEATime{Hour: 23, Minute: 59, Second: 59, Millisecond: 0},
+		canon:    "235959.000",
+	},
+	{
+		input:    "174800.",
+		expected: NMEATime{Hour: 17, Minute: 48, Second: 0, Millisecond: 0},
+		canon:    "174800.000",
+	},
+	{
+		input:    "174800.86499",
+		expected: NMEATime{Hour: 17, Minute: 48, Second: 0, Millisecond: 864},
+		canon:    "174800.864",
+	},
+	{
+		input:    "000000.999",
+		expected: NMEATime{Hour: 0, Minute: 0, Second: 0, Millisecond: 999},
+		canon:    "000000.999",
+	},
+}
+
+func TestParseNMEATime_validInputs(t *testing.T) {
+	for _, vec := range validNMEATimeInputs {
+		t.Run(vec.input, func(t *testing.T) {
+			got, err := parseNMEATime(vec.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != vec.expected {
+				t.Errorf("expected %+v but got %+v", vec.expected, got)
+			}
+		})
+	}
+}
+
+func TestNMEATime_String_roundTrips(t *testing.T) {
+	for _, vec := range validNMEATimeInputs {
+		t.Run(vec.input, func(t *testing.T) {
+			got, err := parseNMEATime(vec.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.String() != vec.canon {
+				t.Errorf("String() expected %q but got %q", vec.canon, got.String())
+			}
+		})
+	}
+}
+
+var invalidNMEATimeInputs = []string{
+	"",
+	"bad_FixTime",
+	"174800.864.0",
+	"45",
+	"1748XX.864",
+	"174800.XY",
+	"994800.000",
+	"174899.000",
+	"174861.000",
+	"1234567",
+	"125960.000",
+	"225960.000",
+	"235961.000",
+	" 174800.864",
+	"ab4812",
+	"12ab34",
+	"176099.000",
+	"174800.-50",
+}
+
+func TestParseNMEATime_invalidInputs(t *testing.T) {
+	for _, input := range invalidNMEATimeInputs {
+		t.Run(input, func(t *testing.T) {
+			_, err := parseNMEATime(input)
+			if err == nil {
+				t.Errorf("expected an error for input %q but got nil", input)
+			}
+		})
+	}
+}
+
+func TestParseNMEATime_invalidInputs_errorMessages(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "ab4812", want: "invalid hour"},
+		{input: "12ab34", want: "invalid minute"},
+		{input: "176099.000", want: "minute 60 out of range [0, 59]"},
+		{input: "174800.-50", want: "millisecond -50 out of range [0, 999]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			_, err := parseNMEATime(tt.input)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if got := err.Error(); got != tt.want {
+				t.Errorf("error %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateNMEATimeFields_millisecondOver999(t *testing.T) {
+	err := validateNMEATimeFields(0, 0, 0, 1000)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	want := "millisecond 1000 out of range [0, 999]"
+	if err.Error() != want {
+		t.Errorf("error %q, want %q", err.Error(), want)
+	}
+}
+
+func TestSegmentParser_AsNMEATime(t *testing.T) {
+	t.Run("Good Data", func(t *testing.T) {
+		p := mustParse(t)
+		expected := NMEATime{Hour: 18, Minute: 37, Second: 30, Millisecond: 0}
+		actual := p.AsNMEATime(1) // segment [1] = "183730"
+		if actual != expected {
+			t.Errorf("expected %+v but got %+v", expected, actual)
+		}
+		if p.Err() != nil {
+			t.Errorf("expected no error but got %v", p.Err())
+		}
+	})
+
+	t.Run("Empty Segment", func(t *testing.T) {
+		p := mustParse(t)
+		actual := p.AsNMEATime(13) // segment [13] is empty
+		if actual != (NMEATime{}) {
+			t.Errorf("expected zero NMEATime for empty segment but got %+v", actual)
+		}
+		if p.Err() != nil {
+			t.Errorf("expected no error for empty segment but got %v", p.Err())
+		}
+	})
+}
+
+func TestSegmentParser_AsNMEATime_errors(t *testing.T) {
+	t.Run("Unparsable Value", func(t *testing.T) {
+		p := mustParse(t)
+		p.segments[1] = "bad_time"
+		actual := p.AsNMEATime(1)
+		if actual != (NMEATime{}) {
+			t.Errorf("expected zero NMEATime on parse failure but got %+v", actual)
+		}
+		if p.Err() == nil {
+			t.Error("expected an error for unparsable value but got nil")
+		}
+		expectedMsg := "sentence segment [1] must be parsable as an NMEATime but was \"bad_time\""
+		if p.Err().Error() != expectedMsg {
+			t.Errorf("expected error %q but got %q", expectedMsg, p.Err().Error())
+		}
+	})
+
+	t.Run("Out-of-Range Index", func(t *testing.T) {
+		p := mustParse(t)
+		actual := p.AsNMEATime(99)
+		if actual != (NMEATime{}) {
+			t.Errorf("expected zero NMEATime on out-of-range index but got %+v", actual)
+		}
+		if p.Err() == nil {
+			t.Error("expected an error for out-of-range index but got nil")
+		}
+	})
+
+	t.Run("Pre-existing Error", func(t *testing.T) {
+		p := mustParse(t)
+		p.AsNMEATime(99) // sets error
+		firstErr := p.Err()
+		p.AsNMEATime(1) // should exit early, leaving error unchanged
+		if !errors.Is(p.Err(), firstErr) {
+			t.Errorf("expected error to remain unchanged but it changed to %v", p.Err())
+		}
+	})
+}

--- a/sentence/parser.go
+++ b/sentence/parser.go
@@ -139,6 +139,31 @@ func (p *SegmentParser) AsInt32(i int8) int32 {
 	return p.asInt(i, 32).(int32)
 }
 
+// AsNMEATime parses the sentence segment at the specified index as an NMEATime value. If p.Err()
+// is not nil, this function returns NMEATime{} and leaves the error unchanged. An empty segment
+// returns NMEATime{} with no error.
+func (p *SegmentParser) AsNMEATime(i int8) NMEATime {
+	if p.checkInRange(i); p.err != nil {
+		return NMEATime{}
+	}
+
+	if p.segments[i] == "" {
+		return NMEATime{}
+	}
+
+	t, err := parseNMEATime(p.segments[i])
+	if err != nil {
+		p.err = &ParsingError{
+			Segment: i,
+			Message: fmt.Sprintf("must be parsable as an NMEATime but was \"%s\"", p.segments[i]),
+		}
+
+		return NMEATime{}
+	}
+
+	return t
+}
+
 // AsString parses the sentence segment at the specified index as a string value. If p.Err() is not
 // nil, this function returns "" and leaves the error unchanged.
 func (p *SegmentParser) AsString(i int8) string {


### PR DESCRIPTION
float32 cannot represent all NMEA time values exactly -- for example, 215102.604 stored as float32 truncates to 215102.60. NMEATime parses the (h)hmmss.sss wire format directly into integer fields (Hour, Minute, Second, Millisecond), eliminating that precision loss.

Changes:
- Add `NMEATime` struct, `parseNMEATime`, and `String()` in `sentence/nmeatime.go`
- Add `SegmentParser.AsNMEATime` in `sentence/parser.go`
- Change `GPGGA.FixTime` and `GPGLL.FixTime` from `float32` to `NMEATime`
- Update tests and README accordingly

Closes #14